### PR TITLE
smerc/fix_conftest_wrapped_functions_glitch

### DIFF
--- a/conftest.py
+++ b/conftest.py
@@ -87,7 +87,8 @@ def pytest_terminal_summary(terminalreporter, exitstatus, config):
         return
 
     tainted_reports = get_taint_related_reports(terminalreporter)
-    if len(tainted_reports) < 1: return
+    if len(tainted_reports) < 1:
+        return
 
     terminalreporter.write_sep("=", "TAINT EXCEPTION SUMMARY", purple=True)
 


### PR DESCRIPTION
Prior, the custom pytest taint exception trace summary didn't support nested functions and also appeared when there were no tainted reports. Both of these issues have been resolved.