### PR TITLE
Update OS Command Injection Plugin to Include All Test Cases

### DIFF
--- a/plugins/cwe_78_os_command_injection/__init__.py
+++ b/plugins/cwe_78_os_command_injection/__init__.py
@@ -26,7 +26,7 @@ VERIFIERS = [
     "dataset.cwe_78_os_command_injection.secure_novalidation.app.is_safe_path",
     "dataset.cwe_78_os_command_injection.secure_novalidation_system.app.is_safe_path",
     "dataset.cwe_78_os_command_injection.secure_double_extension.app.is_safe_path",
-    "dataset.cwe_78_os_command_injection.secure_double_extension_system.app.is_safe_path"
+    "dataset.cwe_78_os_command_injection.secure_double_extension_system.app.is_safe_path",
 ]
 
 SANITIZERS = []
@@ -36,36 +36,36 @@ SINKS = ["os.system", "os.popen"]
 TEST_CONFIGS = {
     "insecure_novalidation": {
         "app_path": "dataset.cwe_78_os_command_injection.insecure_novalidation.app",
-        "route": "/insecure"
+        "route": "/insecure",
     },
     "secure_novalidation": {
         "app_path": "dataset.cwe_78_os_command_injection.secure_novalidation.app",
-        "route": "/secure"
+        "route": "/secure",
     },
     "insecure_novalidation_system": {
         "app_path": "dataset.cwe_78_os_command_injection.insecure_novalidation_system.app",
-        "route": "/insecure"
+        "route": "/insecure",
     },
     "secure_novalidation_system": {
         "app_path": "dataset.cwe_78_os_command_injection.secure_novalidation_system.app",
-        "route": "/secure"
+        "route": "/secure",
     },
     "insecure_double_extension": {
         "app_path": "dataset.cwe_78_os_command_injection.insecure_double_extension.app",
-        "route": "/insecure"
+        "route": "/insecure",
     },
     "secure_double_extension": {
         "app_path": "dataset.cwe_78_os_command_injection.secure_double_extension.app",
-        "route": "/secure"
+        "route": "/secure",
     },
     "insecure_double_extension_system": {
         "app_path": "dataset.cwe_78_os_command_injection.insecure_double_extension_system.app",
-        "route": "/insecure"
+        "route": "/insecure",
     },
     "secure_double_extension_system": {
         "app_path": "dataset.cwe_78_os_command_injection.secure_double_extension_system.app",
-        "route": "/secure"
-    }
+        "route": "/secure",
+    },
 }
 
 
@@ -152,7 +152,9 @@ def test_fuzz_secure_double_extension(taintmonkey):
             client.get(f"{taintmonkey.route}?{urlencode({'file': data})}")
 
 
-@pytest.mark.parametrize("taintmonkey", ["insecure_double_extension_system"], indirect=True)
+@pytest.mark.parametrize(
+    "taintmonkey", ["insecure_double_extension_system"], indirect=True
+)
 def test_fuzz_insecure_double_extension_system(taintmonkey):
     fuzzer = taintmonkey.get_fuzzer()
     with fuzzer.get_context() as (client, get_input):
@@ -161,7 +163,9 @@ def test_fuzz_insecure_double_extension_system(taintmonkey):
                 client.get(f"{taintmonkey.route}?{urlencode({'file': data})}")
 
 
-@pytest.mark.parametrize("taintmonkey", ["secure_double_extension_system"], indirect=True)
+@pytest.mark.parametrize(
+    "taintmonkey", ["secure_double_extension_system"], indirect=True
+)
 def test_fuzz_secure_double_extension_system(taintmonkey):
     fuzzer = taintmonkey.get_fuzzer()
     with fuzzer.get_context() as (client, get_input):
@@ -171,4 +175,3 @@ def test_fuzz_secure_double_extension_system(taintmonkey):
 
 if __name__ == "__main__":
     sys.exit(pytest.main([__file__]))
-

--- a/plugins/cwe_78_os_command_injection/__init__.py
+++ b/plugins/cwe_78_os_command_injection/__init__.py
@@ -10,10 +10,8 @@ From the root of the repository, run the following:
     PYTHONPATH=. python3 plugins/cwe_78_os_command_injection/__init__.py
 """
 
-import sys
-import os
 import pytest
-import importlib
+import sys
 from urllib.parse import urlencode
 
 from taintmonkey import TaintException, TaintMonkey
@@ -21,156 +19,163 @@ from taintmonkey.fuzzer import DictionaryFuzzer
 from taintmonkey.taint import TaintedStr
 from taintmonkey.patch import original_function
 
-
 VERIFIERS = [
     "dataset.cwe_78_os_command_injection.secure_novalidation.app.is_safe_path",
     "dataset.cwe_78_os_command_injection.secure_novalidation_system.app.is_safe_path",
     "dataset.cwe_78_os_command_injection.secure_double_extension.app.is_safe_path",
     "dataset.cwe_78_os_command_injection.secure_double_extension_system.app.is_safe_path",
 ]
-
 SANITIZERS = []
-
 SINKS = ["os.system", "os.popen"]
 
-TEST_CONFIGS = {
-    "insecure_novalidation": {
-        "app_path": "dataset.cwe_78_os_command_injection.insecure_novalidation.app",
-        "route": "/insecure",
-    },
-    "secure_novalidation": {
-        "app_path": "dataset.cwe_78_os_command_injection.secure_novalidation.app",
-        "route": "/secure",
-    },
-    "insecure_novalidation_system": {
-        "app_path": "dataset.cwe_78_os_command_injection.insecure_novalidation_system.app",
-        "route": "/insecure",
-    },
-    "secure_novalidation_system": {
-        "app_path": "dataset.cwe_78_os_command_injection.secure_novalidation_system.app",
-        "route": "/secure",
-    },
-    "insecure_double_extension": {
-        "app_path": "dataset.cwe_78_os_command_injection.insecure_double_extension.app",
-        "route": "/insecure",
-    },
-    "secure_double_extension": {
-        "app_path": "dataset.cwe_78_os_command_injection.secure_double_extension.app",
-        "route": "/secure",
-    },
-    "insecure_double_extension_system": {
-        "app_path": "dataset.cwe_78_os_command_injection.insecure_double_extension_system.app",
-        "route": "/insecure",
-    },
-    "secure_double_extension_system": {
-        "app_path": "dataset.cwe_78_os_command_injection.secure_double_extension_system.app",
-        "route": "/secure",
-    },
-}
 
-
-@pytest.fixture
-def taintmonkey(request):
-    config = TEST_CONFIGS[request.param]
-    app_module = importlib.import_module(config["app_path"])
-    app = app_module.app
+@pytest.fixture()
+def taintmonkey():
+    from dataset.cwe_78_os_command_injection.insecure_novalidation.app import app
 
     tm = TaintMonkey(app, verifiers=VERIFIERS, sanitizers=SANITIZERS, sinks=SINKS)
+
     fuzzer = DictionaryFuzzer(app, "plugins/cwe_78_os_command_injection/corpus.txt")
     tm.set_fuzzer(fuzzer)
 
-    @tm.patch.function(f"{config['app_path']}.open_file_command")
-    def new_open_file_command(file: TaintedStr):
+    @tm.patch.function(
+        "dataset.cwe_78_os_command_injection.insecure_novalidation.app.open_file_command"
+    )
+    def patched_open_file_command(file: TaintedStr):
         return TaintedStr(original_function(file))
 
-    tm.route = config["route"]
+    @tm.patch.function(
+        "dataset.cwe_78_os_command_injection.secure_novalidation.app.open_file_command"
+    )
+    def patched_open_file_command(file: TaintedStr):
+        return TaintedStr(original_function(file))
+        # TODO: if verifier has been called (file is untainted), then this should return an untainted string
+
+    @tm.patch.function(
+        "dataset.cwe_78_os_command_injection.insecure_novalidation_system.app.open_file_command"
+    )
+    def patched_open_file_command(file: TaintedStr):
+        return TaintedStr(original_function(file))
+
+    @tm.patch.function(
+        "dataset.cwe_78_os_command_injection.secure_novalidation_system.app.open_file_command"
+    )
+    def patched_open_file_command(file: TaintedStr):
+        return TaintedStr(original_function(file))
+
+    @tm.patch.function(
+        "dataset.cwe_78_os_command_injection.insecure_double_extension.app.open_file_command"
+    )
+    def patched_open_file_command(file: TaintedStr):
+        return TaintedStr(original_function(file))
+
+    @tm.patch.function(
+        "dataset.cwe_78_os_command_injection.secure_double_extension.app.open_file_command"
+    )
+    def patched_open_file_command(file: TaintedStr):
+        return TaintedStr(original_function(file))
+
+    @tm.patch.function(
+        "dataset.cwe_78_os_command_injection.insecure_double_extension_system.app.open_file_command"
+    )
+    def patched_open_file_command(file: TaintedStr):
+        return TaintedStr(original_function(file))
+
+    @tm.patch.function(
+        "dataset.cwe_78_os_command_injection.secure_double_extension_system.app.open_file_command"
+    )
+    def patched_open_file_command(file: TaintedStr):
+        return TaintedStr(original_function(file))
+
     return tm
 
 
-@pytest.mark.parametrize("taintmonkey", ["insecure_novalidation"], indirect=True)
-def test_taint_exception(taintmonkey):
-    client = taintmonkey.get_client()
-    with pytest.raises(TaintException):
-        client.get(f"{taintmonkey.route}?file=/etc/passwd")
+# def test_fuzz_insecure_novalidation(taintmonkey):
+#     from dataset.cwe_78_os_command_injection.insecure_novalidation.app import app
+
+#     taintmonkey.set_app(app)
+
+#     with taintmonkey.get_fuzzer().get_context() as (client, get_input):
+#         for data in get_input():
+#             with pytest.raises(TaintException):
+#                 client.get(f"/insecure?{urlencode({'file': data})}")
 
 
-@pytest.mark.parametrize("taintmonkey", ["insecure_novalidation"], indirect=True)
-def test_command_injection(taintmonkey):
-    client = taintmonkey.get_client()
-    with pytest.raises(TaintException):
-        client.get(f"{taintmonkey.route}?file=example.txt;ls")
-
-
-@pytest.mark.parametrize("taintmonkey", ["insecure_novalidation"], indirect=True)
-def test_fuzz_insecure_novalidation(taintmonkey):
-    fuzzer = taintmonkey.get_fuzzer()
-    with fuzzer.get_context() as (client, get_input):
-        for data in get_input():
-            with pytest.raises(TaintException):
-                client.get(f"{taintmonkey.route}?{urlencode({'file': data})}")
-
-
-@pytest.mark.parametrize("taintmonkey", ["secure_novalidation"], indirect=True)
 def test_fuzz_secure_novalidation(taintmonkey):
-    fuzzer = taintmonkey.get_fuzzer()
-    with fuzzer.get_context() as (client, get_input):
+    from dataset.cwe_78_os_command_injection.secure_novalidation.app import app
+
+    taintmonkey.set_app(app)
+
+    with taintmonkey.get_fuzzer().get_context() as (client, get_input):
         for data in get_input():
-            client.get(f"{taintmonkey.route}?{urlencode({'file': data})}")
+            client.get(f"/secure?{urlencode({'file': data})}")
 
 
-@pytest.mark.parametrize("taintmonkey", ["insecure_novalidation_system"], indirect=True)
-def test_fuzz_insecure_novalidation_system(taintmonkey):
-    fuzzer = taintmonkey.get_fuzzer()
-    with fuzzer.get_context() as (client, get_input):
-        for data in get_input():
-            with pytest.raises(TaintException):
-                client.get(f"{taintmonkey.route}?{urlencode({'file': data})}")
+# def test_fuzz_insecure_novalidation_system(taintmonkey):
+#     from dataset.cwe_78_os_command_injection.insecure_novalidation_system.app import app
+
+#     taintmonkey.set_app(app)
+
+#     with taintmonkey.get_fuzzer().get_context() as (client, get_input):
+#         for data in get_input():
+#             with pytest.raises(TaintException):
+#                 client.get(f"/insecure?{urlencode({'file': data})}")
 
 
-@pytest.mark.parametrize("taintmonkey", ["secure_novalidation_system"], indirect=True)
-def test_fuzz_secure_novalidation_system(taintmonkey):
-    fuzzer = taintmonkey.get_fuzzer()
-    with fuzzer.get_context() as (client, get_input):
-        for data in get_input():
-            client.get(f"{taintmonkey.route}?{urlencode({'file': data})}")
+# def test_fuzz_secure_novalidation_system(taintmonkey):
+#     from dataset.cwe_78_os_command_injection.secure_novalidation_system.app import app
+
+#     taintmonkey.set_app(app)
+
+#     with taintmonkey.get_fuzzer().get_context() as (client, get_input):
+#         for data in get_input():
+#             client.get(f"/secure?{urlencode({'file': data})}")
 
 
-@pytest.mark.parametrize("taintmonkey", ["insecure_double_extension"], indirect=True)
-def test_fuzz_insecure_double_extension(taintmonkey):
-    fuzzer = taintmonkey.get_fuzzer()
-    with fuzzer.get_context() as (client, get_input):
-        for data in get_input():
-            with pytest.raises(TaintException):
-                client.get(f"{taintmonkey.route}?{urlencode({'file': data})}")
+# def test_fuzz_insecure_double_extension(taintmonkey):
+#     from dataset.cwe_78_os_command_injection.insecure_double_extension.app import app
+
+#     taintmonkey.set_app(app)
+
+#     with taintmonkey.get_fuzzer().get_context() as (client, get_input):
+#         for data in get_input():
+#             with pytest.raises(TaintException):
+#                 client.get(f"/insecure?{urlencode({'file': data})}")
 
 
-@pytest.mark.parametrize("taintmonkey", ["secure_double_extension"], indirect=True)
 def test_fuzz_secure_double_extension(taintmonkey):
-    fuzzer = taintmonkey.get_fuzzer()
-    with fuzzer.get_context() as (client, get_input):
+    from dataset.cwe_78_os_command_injection.secure_double_extension.app import app
+
+    taintmonkey.set_app(app)
+
+    with taintmonkey.get_fuzzer().get_context() as (client, get_input):
         for data in get_input():
-            client.get(f"{taintmonkey.route}?{urlencode({'file': data})}")
+            client.get(f"/secure?{urlencode({'file': data})}")
 
 
-@pytest.mark.parametrize(
-    "taintmonkey", ["insecure_double_extension_system"], indirect=True
-)
-def test_fuzz_insecure_double_extension_system(taintmonkey):
-    fuzzer = taintmonkey.get_fuzzer()
-    with fuzzer.get_context() as (client, get_input):
-        for data in get_input():
-            with pytest.raises(TaintException):
-                client.get(f"{taintmonkey.route}?{urlencode({'file': data})}")
+# def test_fuzz_insecure_double_extension_system(taintmonkey):
+#     from dataset.cwe_78_os_command_injection.insecure_double_extension_system.app import (
+#         app,
+#     )
+
+#     taintmonkey.set_app(app)
+
+#     with taintmonkey.get_fuzzer().get_context() as (client, get_input):
+#         for data in get_input():
+#             with pytest.raises(TaintException):
+#                 client.get(f"/insecure?{urlencode({'file': data})}")
 
 
-@pytest.mark.parametrize(
-    "taintmonkey", ["secure_double_extension_system"], indirect=True
-)
-def test_fuzz_secure_double_extension_system(taintmonkey):
-    fuzzer = taintmonkey.get_fuzzer()
-    with fuzzer.get_context() as (client, get_input):
-        for data in get_input():
-            client.get(f"{taintmonkey.route}?{urlencode({'file': data})}")
+# def test_fuzz_secure_double_extension_system(taintmonkey):
+#     from dataset.cwe_78_os_command_injection.secure_double_extension_system.app import (
+#         app,
+#     )
+
+#     taintmonkey.set_app(app)
+
+#     with taintmonkey.get_fuzzer().get_context() as (client, get_input):
+#         for data in get_input():
+#             client.get(f"/secure?{urlencode({'file': data})}")
 
 
 if __name__ == "__main__":

--- a/plugins/cwe_78_os_command_injection/__init__.py
+++ b/plugins/cwe_78_os_command_injection/__init__.py
@@ -5,108 +5,170 @@ CWE-78: Improper Neutralization of Special Elements used in an OS Command ('OS C
 https://cwe.mitre.org/data/definitions/78.html
 
 # How to run?
-From the root of the repository, run the following.
+From the root of the repository, run the following:
 
-```
-PYTHONPATH=. python3 plugins/cwe_78_os_command_injection/__init__.py
-```
+    PYTHONPATH=. python3 plugins/cwe_78_os_command_injection/__init__.py
 """
 
+import sys
+import os
 import pytest
+import importlib
+from urllib.parse import urlencode
 
 from taintmonkey import TaintException, TaintMonkey
 from taintmonkey.fuzzer import DictionaryFuzzer
 from taintmonkey.taint import TaintedStr
-from taintmonkey.patch import patch_function, original_function
-
-import os, sys
-from urllib.parse import urlencode
+from taintmonkey.patch import original_function
 
 
-VERIFIERS = []
+VERIFIERS = [
+    "dataset.cwe_78_os_command_injection.secure_novalidation.app.is_safe_path",
+    "dataset.cwe_78_os_command_injection.secure_novalidation_system.app.is_safe_path",
+    "dataset.cwe_78_os_command_injection.secure_double_extension.app.is_safe_path",
+    "dataset.cwe_78_os_command_injection.secure_double_extension_system.app.is_safe_path"
+]
+
 SANITIZERS = []
+
 SINKS = ["os.system", "os.popen"]
 
+TEST_CONFIGS = {
+    "insecure_novalidation": {
+        "app_path": "dataset.cwe_78_os_command_injection.insecure_novalidation.app",
+        "route": "/insecure"
+    },
+    "secure_novalidation": {
+        "app_path": "dataset.cwe_78_os_command_injection.secure_novalidation.app",
+        "route": "/secure"
+    },
+    "insecure_novalidation_system": {
+        "app_path": "dataset.cwe_78_os_command_injection.insecure_novalidation_system.app",
+        "route": "/insecure"
+    },
+    "secure_novalidation_system": {
+        "app_path": "dataset.cwe_78_os_command_injection.secure_novalidation_system.app",
+        "route": "/secure"
+    },
+    "insecure_double_extension": {
+        "app_path": "dataset.cwe_78_os_command_injection.insecure_double_extension.app",
+        "route": "/insecure"
+    },
+    "secure_double_extension": {
+        "app_path": "dataset.cwe_78_os_command_injection.secure_double_extension.app",
+        "route": "/secure"
+    },
+    "insecure_double_extension_system": {
+        "app_path": "dataset.cwe_78_os_command_injection.insecure_double_extension_system.app",
+        "route": "/insecure"
+    },
+    "secure_double_extension_system": {
+        "app_path": "dataset.cwe_78_os_command_injection.secure_double_extension_system.app",
+        "route": "/secure"
+    }
+}
 
-@pytest.fixture()
-def taintmonkey():
-    from dataset.cwe_78_os_command_injection.insecure_novalidation.app import app
+
+@pytest.fixture
+def taintmonkey(request):
+    config = TEST_CONFIGS[request.param]
+    app_module = importlib.import_module(config["app_path"])
+    app = app_module.app
 
     tm = TaintMonkey(app, verifiers=VERIFIERS, sanitizers=SANITIZERS, sinks=SINKS)
-
     fuzzer = DictionaryFuzzer(app, "plugins/cwe_78_os_command_injection/corpus.txt")
     tm.set_fuzzer(fuzzer)
 
-    @patch_function(
-        "dataset.cwe_78_os_command_injection.insecure_novalidation.app.open_file_command"
-    )
+    @tm.patch.function(f"{config['app_path']}.open_file_command")
     def new_open_file_command(file: TaintedStr):
         return TaintedStr(original_function(file))
 
-    @patch_function(
-        "dataset.cwe_78_os_command_injection.secure_novalidation.app.open_file_command"
-    )
-    def new_open_file_command(file: TaintedStr):
-        return TaintedStr(original_function(file))
-
-    @patch_function(
-        "dataset.cwe_78_os_command_injection.insecure_novalidation_system.app.open_file_command"
-    )
-    def new_open_file_command(file: TaintedStr):
-        return TaintedStr(original_function(file))
-
-    @patch_function(
-        "dataset.cwe_78_os_command_injection.secure_novalidation_system.app.open_file_command"
-    )
-    def new_open_file_command(file: TaintedStr):
-        return TaintedStr(original_function(file))
-
-    @patch_function(
-        "dataset.cwe_78_os_command_injection.insecure_double_extension.app.open_file_command"
-    )
-    def new_open_file_command(file: TaintedStr):
-        return TaintedStr(original_function(file))
-
-    @patch_function(
-        "dataset.cwe_78_os_command_injection.secure_double_extension.app.open_file_command"
-    )
-    def new_open_file_command(file: TaintedStr):
-        return TaintedStr(original_function(file))
-
-    @patch_function(
-        "dataset.cwe_78_os_command_injection.insecure_double_extension_system.app.open_file_command"
-    )
-    def new_open_file_command(file: TaintedStr):
-        return TaintedStr(original_function(file))
-
-    @patch_function(
-        "dataset.cwe_78_os_command_injection.secure_double_extension_system.app.open_file_command"
-    )
-    def new_open_file_command(file: TaintedStr):
-        return TaintedStr(original_function(file))
-
+    tm.route = config["route"]
     return tm
 
 
+@pytest.mark.parametrize("taintmonkey", ["insecure_novalidation"], indirect=True)
 def test_taint_exception(taintmonkey):
     client = taintmonkey.get_client()
     with pytest.raises(TaintException):
-        client.get("/insecure?file=/etc/passwd")
+        client.get(f"{taintmonkey.route}?file=/etc/passwd")
 
 
+@pytest.mark.parametrize("taintmonkey", ["insecure_novalidation"], indirect=True)
 def test_command_injection(taintmonkey):
     client = taintmonkey.get_client()
     with pytest.raises(TaintException):
-        client.get(f"/insecure?file=example.txt;ls")
+        client.get(f"{taintmonkey.route}?file=example.txt;ls")
 
 
-def test_fuzz(taintmonkey):
+@pytest.mark.parametrize("taintmonkey", ["insecure_novalidation"], indirect=True)
+def test_fuzz_insecure_novalidation(taintmonkey):
     fuzzer = taintmonkey.get_fuzzer()
     with fuzzer.get_context() as (client, get_input):
         for data in get_input():
             with pytest.raises(TaintException):
-                client.get(f"/insecure?{urlencode({'file': data})}")
+                client.get(f"{taintmonkey.route}?{urlencode({'file': data})}")
+
+
+@pytest.mark.parametrize("taintmonkey", ["secure_novalidation"], indirect=True)
+def test_fuzz_secure_novalidation(taintmonkey):
+    fuzzer = taintmonkey.get_fuzzer()
+    with fuzzer.get_context() as (client, get_input):
+        for data in get_input():
+            client.get(f"{taintmonkey.route}?{urlencode({'file': data})}")
+
+
+@pytest.mark.parametrize("taintmonkey", ["insecure_novalidation_system"], indirect=True)
+def test_fuzz_insecure_novalidation_system(taintmonkey):
+    fuzzer = taintmonkey.get_fuzzer()
+    with fuzzer.get_context() as (client, get_input):
+        for data in get_input():
+            with pytest.raises(TaintException):
+                client.get(f"{taintmonkey.route}?{urlencode({'file': data})}")
+
+
+@pytest.mark.parametrize("taintmonkey", ["secure_novalidation_system"], indirect=True)
+def test_fuzz_secure_novalidation_system(taintmonkey):
+    fuzzer = taintmonkey.get_fuzzer()
+    with fuzzer.get_context() as (client, get_input):
+        for data in get_input():
+            client.get(f"{taintmonkey.route}?{urlencode({'file': data})}")
+
+
+@pytest.mark.parametrize("taintmonkey", ["insecure_double_extension"], indirect=True)
+def test_fuzz_insecure_double_extension(taintmonkey):
+    fuzzer = taintmonkey.get_fuzzer()
+    with fuzzer.get_context() as (client, get_input):
+        for data in get_input():
+            with pytest.raises(TaintException):
+                client.get(f"{taintmonkey.route}?{urlencode({'file': data})}")
+
+
+@pytest.mark.parametrize("taintmonkey", ["secure_double_extension"], indirect=True)
+def test_fuzz_secure_double_extension(taintmonkey):
+    fuzzer = taintmonkey.get_fuzzer()
+    with fuzzer.get_context() as (client, get_input):
+        for data in get_input():
+            client.get(f"{taintmonkey.route}?{urlencode({'file': data})}")
+
+
+@pytest.mark.parametrize("taintmonkey", ["insecure_double_extension_system"], indirect=True)
+def test_fuzz_insecure_double_extension_system(taintmonkey):
+    fuzzer = taintmonkey.get_fuzzer()
+    with fuzzer.get_context() as (client, get_input):
+        for data in get_input():
+            with pytest.raises(TaintException):
+                client.get(f"{taintmonkey.route}?{urlencode({'file': data})}")
+
+
+@pytest.mark.parametrize("taintmonkey", ["secure_double_extension_system"], indirect=True)
+def test_fuzz_secure_double_extension_system(taintmonkey):
+    fuzzer = taintmonkey.get_fuzzer()
+    with fuzzer.get_context() as (client, get_input):
+        for data in get_input():
+            client.get(f"{taintmonkey.route}?{urlencode({'file': data})}")
 
 
 if __name__ == "__main__":
     sys.exit(pytest.main([__file__]))
+

--- a/plugins/cwe_78_os_command_injection/__init__.py
+++ b/plugins/cwe_78_os_command_injection/__init__.py
@@ -20,10 +20,7 @@ from taintmonkey.taint import TaintedStr
 from taintmonkey.patch import original_function
 
 VERIFIERS = [
-    "dataset.cwe_78_os_command_injection.secure_novalidation.app.is_safe_path",
-    "dataset.cwe_78_os_command_injection.secure_novalidation_system.app.is_safe_path",
-    "dataset.cwe_78_os_command_injection.secure_double_extension.app.is_safe_path",
-    "dataset.cwe_78_os_command_injection.secure_double_extension_system.app.is_safe_path",
+
 ]
 SANITIZERS = []
 SINKS = ["os.system", "os.popen"]
@@ -42,63 +39,94 @@ def taintmonkey():
         "dataset.cwe_78_os_command_injection.insecure_novalidation.app.open_file_command"
     )
     def patched_open_file_command(file: TaintedStr):
-        return TaintedStr(original_function(file))
+        command = TaintedStr(original_function(file))
+        if not file.is_tainted():
+            command.sanitize()
+        return command
 
     @tm.patch.function(
         "dataset.cwe_78_os_command_injection.secure_novalidation.app.open_file_command"
     )
     def patched_open_file_command(file: TaintedStr):
-        return TaintedStr(original_function(file))
-        # TODO: if verifier has been called (file is untainted), then this should return an untainted string
+        command = TaintedStr(original_function(file))
+        if not file.is_tainted():
+            command.sanitize()
+        return command
+
+    @tm.patch.function(
+        "dataset.cwe_78_os_command_injection.secure_novalidation.app.is_safe_path"
+    )
+    def patched_is_safe_path(path):
+        # path.sanitize()
+        # print(f"\n\nhello\n\n")
+        return original_function(path)
 
     @tm.patch.function(
         "dataset.cwe_78_os_command_injection.insecure_novalidation_system.app.open_file_command"
     )
     def patched_open_file_command(file: TaintedStr):
-        return TaintedStr(original_function(file))
+        command = TaintedStr(original_function(file))
+        if not file.is_tainted():
+            command.sanitize()
+        return command
 
     @tm.patch.function(
         "dataset.cwe_78_os_command_injection.secure_novalidation_system.app.open_file_command"
     )
     def patched_open_file_command(file: TaintedStr):
-        return TaintedStr(original_function(file))
+        command = TaintedStr(original_function(file))
+        if not file.is_tainted():
+            command.sanitize()
+        return command
 
     @tm.patch.function(
         "dataset.cwe_78_os_command_injection.insecure_double_extension.app.open_file_command"
     )
     def patched_open_file_command(file: TaintedStr):
-        return TaintedStr(original_function(file))
+        command = TaintedStr(original_function(file))
+        if not file.is_tainted():
+            command.sanitize()
+        return command
 
     @tm.patch.function(
         "dataset.cwe_78_os_command_injection.secure_double_extension.app.open_file_command"
     )
     def patched_open_file_command(file: TaintedStr):
-        return TaintedStr(original_function(file))
+        command = TaintedStr(original_function(file))
+        if not file.is_tainted():
+            command.sanitize()
+        return command
 
     @tm.patch.function(
         "dataset.cwe_78_os_command_injection.insecure_double_extension_system.app.open_file_command"
     )
     def patched_open_file_command(file: TaintedStr):
-        return TaintedStr(original_function(file))
-
+        command = TaintedStr(original_function(file))
+        if not file.is_tainted():
+            command.sanitize()
+        return command
+    
     @tm.patch.function(
         "dataset.cwe_78_os_command_injection.secure_double_extension_system.app.open_file_command"
     )
     def patched_open_file_command(file: TaintedStr):
-        return TaintedStr(original_function(file))
+        command = TaintedStr(original_function(file))
+        if not file.is_tainted():
+            command.sanitize()
+        return command
 
     return tm
 
 
-# def test_fuzz_insecure_novalidation(taintmonkey):
-#     from dataset.cwe_78_os_command_injection.insecure_novalidation.app import app
+def test_fuzz_insecure_novalidation(taintmonkey):
+    from dataset.cwe_78_os_command_injection.insecure_novalidation.app import app
 
-#     taintmonkey.set_app(app)
+    taintmonkey.set_app(app)
 
-#     with taintmonkey.get_fuzzer().get_context() as (client, get_input):
-#         for data in get_input():
-#             with pytest.raises(TaintException):
-#                 client.get(f"/insecure?{urlencode({'file': data})}")
+    with taintmonkey.get_fuzzer().get_context() as (client, get_input):
+        for data in get_input():
+            with pytest.raises(TaintException):
+                client.get(f"/insecure?{urlencode({'file': data})}")
 
 
 def test_fuzz_secure_novalidation(taintmonkey):
@@ -143,14 +171,14 @@ def test_fuzz_secure_novalidation(taintmonkey):
 #                 client.get(f"/insecure?{urlencode({'file': data})}")
 
 
-def test_fuzz_secure_double_extension(taintmonkey):
-    from dataset.cwe_78_os_command_injection.secure_double_extension.app import app
+# def test_fuzz_secure_double_extension(taintmonkey):
+#     from dataset.cwe_78_os_command_injection.secure_double_extension.app import app
 
-    taintmonkey.set_app(app)
+#     taintmonkey.set_app(app)
 
-    with taintmonkey.get_fuzzer().get_context() as (client, get_input):
-        for data in get_input():
-            client.get(f"/secure?{urlencode({'file': data})}")
+#     with taintmonkey.get_fuzzer().get_context() as (client, get_input):
+#         for data in get_input():
+#             client.get(f"/secure?{urlencode({'file': data})}")
 
 
 # def test_fuzz_insecure_double_extension_system(taintmonkey):

--- a/plugins/cwe_78_os_command_injection/__init__.py
+++ b/plugins/cwe_78_os_command_injection/__init__.py
@@ -25,14 +25,7 @@ from urllib.parse import urlencode
 
 VERIFIERS = []
 SANITIZERS = []
-SINKS = ["os.popen"]
-
-
-@patch_function(
-    "dataset.cwe_78_os_command_injection.insecure_novalidation.app.open_file_command"
-)
-def new_open_file_command(file: TaintedStr):
-    return TaintedStr(original_function(file))
+SINKS = ["os.system", "os.popen"]
 
 
 @pytest.fixture()
@@ -43,6 +36,54 @@ def taintmonkey():
 
     fuzzer = DictionaryFuzzer(app, "plugins/cwe_78_os_command_injection/corpus.txt")
     tm.set_fuzzer(fuzzer)
+
+    @patch_function(
+        "dataset.cwe_78_os_command_injection.insecure_novalidation.app.open_file_command"
+    )
+    def new_open_file_command(file: TaintedStr):
+        return TaintedStr(original_function(file))
+
+    @patch_function(
+        "dataset.cwe_78_os_command_injection.secure_novalidation.app.open_file_command"
+    )
+    def new_open_file_command(file: TaintedStr):
+        return TaintedStr(original_function(file))
+
+    @patch_function(
+        "dataset.cwe_78_os_command_injection.insecure_novalidation_system.app.open_file_command"
+    )
+    def new_open_file_command(file: TaintedStr):
+        return TaintedStr(original_function(file))
+
+    @patch_function(
+        "dataset.cwe_78_os_command_injection.secure_novalidation_system.app.open_file_command"
+    )
+    def new_open_file_command(file: TaintedStr):
+        return TaintedStr(original_function(file))
+
+    @patch_function(
+        "dataset.cwe_78_os_command_injection.insecure_double_extension.app.open_file_command"
+    )
+    def new_open_file_command(file: TaintedStr):
+        return TaintedStr(original_function(file))
+
+    @patch_function(
+        "dataset.cwe_78_os_command_injection.secure_double_extension.app.open_file_command"
+    )
+    def new_open_file_command(file: TaintedStr):
+        return TaintedStr(original_function(file))
+
+    @patch_function(
+        "dataset.cwe_78_os_command_injection.insecure_double_extension_system.app.open_file_command"
+    )
+    def new_open_file_command(file: TaintedStr):
+        return TaintedStr(original_function(file))
+
+    @patch_function(
+        "dataset.cwe_78_os_command_injection.secure_double_extension_system.app.open_file_command"
+    )
+    def new_open_file_command(file: TaintedStr):
+        return TaintedStr(original_function(file))
 
     return tm
 

--- a/plugins/cwe_78_os_command_injection/corpus.txt
+++ b/plugins/cwe_78_os_command_injection/corpus.txt
@@ -7,3 +7,4 @@ $(ls) # $()
 ls; id
 > /var/www/html/out.txt
 < /etc/passwd
+test


### PR DESCRIPTION
Went through all OS command injection test cases and added patched sources to the taintmonkey() fixture. 

All test cases execute predictably when only the necessary sink function is included in the SINKS list. 

However, there is a bug for the use case where multiple sink functions are included in SINKS and the last element is not the appropriate sink function for the test case being executed. 